### PR TITLE
chore(oss): add boilerplate from cfpb oss template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,115 @@
+# CFPB Open Source Code of Conduct
+
+## Introduction
+
+The [Consumer Financial Protection Bureau](https://www.consumerfinance.gov) (CFPB) is committed to 
+building a safe, welcoming, harassment-free culture for everyone. We do not merely want an 
+environment that is free from hostility, we want one that is actively welcoming and inclusive. We 
+want our team, our workplace culture, and our open source community to reflect and celebrate the 
+diversity of the people we serve.
+
+This Code of Conduct summarizes federal anti-harassment law and CFPB policy. 
+
+## Scope
+
+We expect everyone on the CFPB team, and those contributing to our open source community, to exhibit 
+these behaviors and abide by applicable federal laws and CFPB policies. In addition, we expect 
+everyone within CFPB spaces to exhibit these behaviors and refrain from behavior prohibited by 
+anti-harassment laws and federal policies on harassment. These spaces include:
+
+- CFPB’s physical offices
+- CFPB events and meetings
+- All of CFPB’s online forums and virtual collaboration tools, including code repositories
+
+
+## What we strive for
+
+At the CFPB, we strive to create a welcoming and inclusive culture that empowers people to best protect 
+the financial interests of all consumers. That kind of atmosphere requires an open exchange of ideas 
+balanced by thoughtful guidelines. Examples of behavior that contributes to a positive environment 
+for our open source community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community and public
+
+## Unacceptable behavior
+
+To help understand the kinds of behaviors that are illegal or run counter to the culture we seek to 
+foster, we've listed some actions below that violate federal law and CFPB policy. We've also included 
+steps to take if you encounter behavior that runs contrary to this policy.
+
+The CFPB Policy Statement on Equal Employment Opportunity and Workplace Harassment forbids 
+discrimination or harassment based on:
+
+- Race
+- Color
+- Religion
+- Sex (including pregnancy, sexual orientation, transgender status, gender identity or expression, gender non-conformity, or sex stereotyping of any kind)
+- National origin
+- Disability
+- Age (40 years or older)
+- Genetic information
+- Parental status
+- Political affiliation
+- Marital status
+- Uniformed status
+- Membership in a labor organization or union activities
+- Prior equal employment opportunity (EEO) or whistleblower activity
+- Any other factor unrelated to your merit
+
+The policy also forbids harassing conduct, which includes unwelcome conduct based on any (or a combination of) protected traits or characteristics. Such conduct may take the form of any of the following: 
+
+- Offensive jokes, comments, objects, or pictures 
+- Questions about a person’s identity (e.g., disability status, gender identity, sexual orientation, national origin, etc.) 
+- Undue attention 
+- Ridicule or mockery 
+- Insults or put-downs 
+- Touching/physical contact 
+- Slurs or epithets 
+- Threats or other forms of intimidation 
+- Physical or sexual assault
+
+## Reporting violations
+
+If you are a CFPB employee, former CFPB employee, or job applicant to CFPB and believe you have been 
+discriminated against or harassed on the basis of race, color, religion, sex (including pregnancy, 
+sexual orientation, transgender status, gender identity or expression, gender non-conformity, or sex 
+stereotyping of any kind), national origin, disability, age (40 years or older), genetic information, 
+parental status, or retaliated against for prior Equal Employment Opportunity (EEO) activity, contact the CFPB’s Office of Civil Rights.
+
+CFPB_EEO@consumerfinance.gov
+
+(202) 435-9EEO
+(855) 233-0362
+TTY: (202) 435-9742
+
+Office of Civil Rights
+Consumer Financial Protection Bureau
+1700 G Street, NW
+Washington, D.C. 20552
+
+For help filing a complaint about discrimination on the basis of marital status, political 
+affiliation, or any other non-merit factor, or for claims of retaliation for [whistleblower activity](https://www.consumerfinance.gov/office-civil-rights/whistleblowers/), contact the [Office of Special Counsel](https://www.osc.gov/) or the [Merit Systems Protection Board](https://www.mspb.gov/).
+
+For help filing a complaint about discrimination on the basis of uniformed status, you may contact 
+the [Veterans’ Employment and Training Service (VETS)](https://www.dol.gov/vets/) at the Department of Labor, the [Merit Systems Protection Board](https://www.mspb.gov/), or the [Office of Special Counsel](https://osc.gov/), depending on the circumstances.
+
+For help filing a complaint about discrimination on the basis of membership in a labor organization, 
+you may contact the [Federal Labor Relations Authority](https://flra.gov/) or your union (if applicable).
+
+### Equal employment opportunity policy
+
+For more information about the CFPB’s equal employment opportunity (EEO) policies and procedures visit https://www.consumerfinance.gov/office-civil-rights/eeo-policy-and-reports/ 
+
+## Credits
+
+The CFPB is greatly appreciative of the multiple sources that we drew from to build this Code of Conduct, including:
+
+- [The Technology Transformation Services (TTS) Code of Conduct](https://18f.gsa.gov/code-of-conduct/)
+- [The Contributor Covenant](https://www.contributor-covenant.org/)
+- [Code for America Code of Conduct](https://github.com/codeforamerica/codeofconduct)
+- [Ada Initiative: HOWTO design a code of conduct for your community](https://adainitiative.org/2014/02/18/howto-design-a-code-of-conduct-for-your-community/)
+- [Geek Feminism Code of Conduct](https://geekfeminismdotorg.wordpress.com/about/code-of-conduct/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# Guidance on how to contribute
+
+> All contributions to this project will be released under the CC0 public domain
+> dedication. By submitting a pull request or filing a bug, issue, or
+> feature request, you are agreeing to comply with this waiver of copyright interest.
+> Details can be found in our [TERMS](TERMS.md) and [LICENSE](LICENSE).
+
+There are two primary ways to help:
+
+- Using the issue tracker, and
+- Changing the code-base.
+
+## Using the issue tracker
+
+Use the issue tracker to suggest feature requests, report bugs, and ask questions.
+This is also a great way to connect with the developers of the project as well
+as others who are interested in this solution.
+
+Use the issue tracker to find ways to contribute. Find a bug or a feature, mention in
+the issue that you will take on that effort, then follow the _Changing the code-base_
+guidance below.
+
+## Changing the code-base
+
+Generally speaking, you should fork this repository, make changes in your
+own fork, and then submit a pull request. All new code should have associated
+unit tests that validate implemented features and the presence or lack of defects.
+Additionally, the code should follow any stylistic and architectural guidelines
+prescribed by the project. In the absence of such guidelines, mimic the styles
+and patterns in the existing code-base.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,52 @@
+As a work of the United States Government, this package (excluding any
+exceptions listed below) is in the public domain within the United States.
+Additionally, we waive copyright and related rights in the work worldwide
+through the [CC0 1.0 Universal public domain dedication][CC0].
+
+Software source code previously released under an open source license and then
+modified by CFPB staff or its contractors is considered a "joint work"
+(see 17 USC § 101); it is partially copyrighted, partially public domain,
+and as a whole is protected by the copyrights of the non-government authors and
+must be released according to the terms of the original open-source license.
+Segments written by CFPB staff, and by contractors who are developing software
+on behalf of CFPB are also in the public domain, and copyright and related
+rights for that work are waived through the CC0 1.0 Universal dedication.
+
+For further details, please see the CFPB [Source Code Policy][policy].
+
+
+## CC0 1.0 Universal Summary
+
+This is a human-readable summary of the [Legal Code (read the full text)][CC0].
+
+### No Copyright
+
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the
+extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial 
+purposes, all without asking permission. See Other Information below.
+
+### Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0,
+nor are the rights that other persons may have in the work or in how the
+work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with
+this deed makes no warranties about the work, and disclaims liability for
+all uses of the work, to the fullest extent permitted by applicable law.
+When using or citing the work, you should not imply endorsement by the
+author or the affirmer.
+
+[policy]: https://github.com/cfpb/source-code-policy/
+[CC0]: http://creativecommons.org/publicdomain/zero/1.0/legalcode
+
+
+## Exceptions
+
+_Source code or other assets that are excluded from the TERMS should be listed
+here. These may include dependencies that may be licensed differently or are
+not in the public domain._


### PR DESCRIPTION
Since we're sharing this repo with others, we'll want to make sure we add the boilerplate open source template files.

Closes: #5 

## Changes

- includes open source template files [from the CFPB repo](https://github.com/cfpb/open-source-project-template/tree/main) including:
  - Code of conduct
  - Contributing guidelines
  - License
  - Terms